### PR TITLE
S9: OXT-1638: ioctl: FBTAP_IOCGSIZE type width.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.tmp_versions
+.*.cmd
+*.symvers
+*.order
+*.ko
+*.mod.c
+*.o

--- a/fbtap.c
+++ b/fbtap.c
@@ -201,7 +201,7 @@ fbtap_ioctl (struct file *filp, unsigned int cmd, unsigned long arg)
         break;
 
     case FBTAP_IOCGSIZE:
-        put_user (fb->size >> PAGE_SHIFT, (unsigned int*) arg);
+        put_user (fb->size >> PAGE_SHIFT, (unsigned long *)arg);
         break;
 
     case FBTAP_IOCALLOCFB:


### PR DESCRIPTION
FBTAP_IOCGSIZE writes the number of pages used for the framebuffer in an unsigned long, not unsigned int. This was revealed with the switch to 64b kernels.

Add a gitignore while at it.